### PR TITLE
Basic support for junos config in json format

### DIFF
--- a/napalm/junos/junos.py
+++ b/napalm/junos/junos.py
@@ -2459,11 +2459,17 @@ class JunOSDriver(NetworkDriver):
         }
         if retrieve in ("candidate", "all"):
             config = self.device.rpc.get_config(filter_xml=None, options=options)
-            rv["candidate"] = str(config.text)
+            if options["format"] == "text":
+                rv["candidate"] = str(config.text)
+            else:
+                rv["candidate"] = str(config["configuration"])
         if retrieve in ("running", "all"):
             options["database"] = "committed"
             config = self.device.rpc.get_config(filter_xml=None, options=options)
-            rv["running"] = str(config.text)
+            if options["format"] == "text":
+                rv["running"] = str(config.text)
+            else:
+                 rv["running"] = str(config["configuration"])
 
         if sanitized:
             return napalm.base.helpers.sanitize_configs(rv, sanitize_strings)


### PR DESCRIPTION
When you specify format=json in getters_options the result value is dict, not string These are merged and corrected commits i posted yesterday. I hope its clean now :)